### PR TITLE
Center seller image for any screen size

### DIFF
--- a/frontend/src/custom.scss
+++ b/frontend/src/custom.scss
@@ -57,5 +57,5 @@ body {
 }
 
 .user-info {
-  min-width: 800px;
+  min-width: none;
 }


### PR DESCRIPTION
# Description


Mobile users affected only. Image of sellers is off centered when screen size decreases in width.

Before: 
<img width="641" alt="Screenshot 2022-12-10 at 11 27 41 PM" src="https://user-images.githubusercontent.com/18019914/206891488-ae320ca2-4e43-4210-ba68-4f662d879bfc.png">

After:
<img width="506" alt="Screenshot 2022-12-10 at 11 27 23 PM" src="https://user-images.githubusercontent.com/18019914/206891494-88f46796-c3d7-494d-880f-d2d4c2dbf5b5.png">